### PR TITLE
Add statespace references to QAtoms and introduce QEq abstraction

### DIFF
--- a/src/QExpressionsOps/QExpressionsAlgebra.jl
+++ b/src/QExpressionsOps/QExpressionsAlgebra.jl
@@ -207,7 +207,7 @@ function multiply_qterm(t1::QTerm, t2::QTerm, statespace::StateSpace)::Tuple{Vec
             new_factor *= c[1]
             push!(new_term, c[2])
         end
-        push!(new_terms, QTerm(new_term))
+        push!(new_terms, QTerm(statespace, new_term))
         push!(new_coeffs, new_factor)
     end
     return new_terms, new_coeffs
@@ -369,7 +369,7 @@ function Identity(qspace::StateSpace)
     # Build a vector of neutral operator indexes.
     neutral_ops = [s.op_set.neutral_element for s in qspace.subspaces for key in s.keys]
     # Create a single-term qExpr.
-    return qExpr(qspace, QAtomProduct(qspace, qspace.fone, QAtom[QTerm(qspace.neutral_op)]))
+    return qExpr(qspace, QAtomProduct(qspace, qspace.fone, QAtom[QTerm(qspace, qspace.neutral_op)]))
 end
 
 """
@@ -402,7 +402,7 @@ function Dag(qspace::StateSpace, t::QTerm)::Vector{Tuple{QTerm, ComplexRational}
             curr_coeff *= combo[i][1]
             push!(curr_inds, combo[i][2])
         end
-        push!(terms, QTerm(curr_inds))
+        push!(terms, QTerm(qspace, curr_inds))
         push!(coeffs, curr_coeff)
     end
     return collect(zip(terms, coeffs))

--- a/src/QExpressionsOps/QExpressions_base_operators.jl
+++ b/src/QExpressionsOps/QExpressions_base_operators.jl
@@ -40,7 +40,7 @@ function base_operators(statespace::StateSpace; do_fun::Bool=false, formatted::B
             for base_op in base_ops
                 curr_operator = copy(neutral_operator)
                 curr_operator[index] = base_op
-                term = QTerm(curr_operator)
+                term = QTerm(statespace, curr_operator)
                 curr_name = op_set.op2str(base_op, key, formatted=formatted)
                 op_dict[curr_name] = qExpr(statespace, term)
             end
@@ -53,7 +53,7 @@ function base_operators(statespace::StateSpace; do_fun::Bool=false, formatted::B
                     curr_operator = copy(neutral_operator)
                     curr_operator[index] = op[2]
                     coeff = op[1]
-                    curr_prod = QAtomProduct(statespace, coeff, copy(var_exponents), QTerm(copy(curr_operator)))
+                    curr_prod = QAtomProduct(statespace, coeff, copy(var_exponents), QTerm(statespace, copy(curr_operator)))
                     push!(curr_terms, curr_prod)
                 end
                 if formatted
@@ -71,9 +71,9 @@ function base_operators(statespace::StateSpace; do_fun::Bool=false, formatted::B
     abstract_dict::Dict{String, Union{Function, qExpr}} = Dict()
     for (key_index, (name, operatortype)) in enumerate(zip(statespace.operator_names, statespace.operatortypes))
         if do_fun
-            abstract_dict[name] = (subindex=-1) -> qExpr(statespace, QAbstract(operatortype, key_index, subindex))
+            abstract_dict[name] = (subindex=-1) -> qExpr(statespace, QAbstract(statespace, operatortype, key_index, subindex))
         else
-            abstract_dict[name] = qExpr(statespace, QAbstract(operatortype, key_index))
+            abstract_dict[name] = qExpr(statespace, QAbstract(statespace, operatortype, key_index))
         end
     end
     return var_dict, op_dict, abstract_dict
@@ -108,7 +108,7 @@ function base_operators(statespace::StateSpace, name::String; do_fun::Bool=false
                 for base_op in base_ops
                     curr_operator = copy(neutral_operator)
                     curr_operator[index] = base_op
-                    term = QTerm(curr_operator)
+                    term = QTerm(statespace, curr_operator)
                     curr_name = op_set.op2str(base_op, key, formatted=formatted)
                     op_dict[curr_name] = qExpr(statespace, term)
                 end
@@ -121,7 +121,7 @@ function base_operators(statespace::StateSpace, name::String; do_fun::Bool=false
                         curr_operator = copy(neutral_operator)
                         curr_operator[index] = op[2]
                         coeff = op[1]
-                        curr_prod = QAtomProduct(statespace, coeff, copy(var_exponents), QTerm(copy(curr_operator)))
+                        curr_prod = QAtomProduct(statespace, coeff, copy(var_exponents), QTerm(statespace, copy(curr_operator)))
                         push!(curr_terms, curr_prod)
                     end
                     if formatted
@@ -141,13 +141,13 @@ function base_operators(statespace::StateSpace, name::String; do_fun::Bool=false
         if do_fun 
             abstract_dict::Dict{String, Function} = Dict()  
             for (key_index, (name, operatortype)) in enumerate(zip(statespace.operator_names, statespace.operatortypes))
-                abstract_dict[name] = (subindex=-1) -> qExpr(statespace, QAbstract(operatortype, key_index, subindex))
+                abstract_dict[name] = (subindex=-1) -> qExpr(statespace, QAbstract(statespace, operatortype, key_index, subindex))
             end
             return abstract_dict
         else
             abstract_dict2::Dict{String, qExpr} = Dict()
             for (key_index, (name, operatortype)) in enumerate(zip(statespace.operator_names, statespace.operatortypes))
-                abstract_dict2[name] = qExpr(statespace, QAbstract(operatortype, key_index))
+                abstract_dict2[name] = qExpr(statespace, QAbstract(statespace, operatortype, key_index))
             end
             return abstract_dict2
         end
@@ -211,9 +211,9 @@ function base_operators(statespace::StateSpace, name::String; do_fun::Bool=false
                         op_str = inner_key * "_" * key 
                     end 
                     if do_dict
-                        curr_ops[op_str] = qExpr(statespace, QTerm(copy(curr_operator)))
+                        curr_ops[op_str] = qExpr(statespace, QTerm(statespace, copy(curr_operator)))
                     else
-                        push!(ops_vec, qExpr(statespace, QTerm(copy(curr_operator))))
+                        push!(ops_vec, qExpr(statespace, QTerm(statespace, copy(curr_operator))))
                     end
                 end
 
@@ -225,7 +225,7 @@ function base_operators(statespace::StateSpace, name::String; do_fun::Bool=false
                         curr_operator = copy(neutral_operator)
                         curr_operator[index] = op[2]
                         coeff = op[1]
-                        curr_prod = QAtomProduct(statespace,coeff, copy(var_exponents), QTerm(copy(curr_operator)))
+                        curr_prod = QAtomProduct(statespace,coeff, copy(var_exponents), QTerm(statespace, copy(curr_operator)))
                         push!(curr_terms, curr_prod)
                     end
                     if formatted
@@ -251,10 +251,10 @@ function base_operators(statespace::StateSpace, name::String; do_fun::Bool=false
     # check for abstract operators
     for (key_index, (curr_name, operatortype)) in enumerate(zip(statespace.operator_names, statespace.operatortypes))
         if name == curr_name
-            if do_fun 
-                return (subindex=-1) -> qExpr(statespace, QAbstract(operatortype, key_index, subindex))
+            if do_fun
+                return (subindex=-1) -> qExpr(statespace, QAbstract(statespace, operatortype, key_index, subindex))
             else
-                return qExpr(statespace, QAbstract(operatortype, key_index))
+                return qExpr(statespace, QAbstract(statespace, operatortype, key_index))
             end
         else
             if contains(name, "_")

--- a/src/QExpressionsOps/QExpressions_cumulants.jl
+++ b/src/QExpressionsOps/QExpressions_cumulants.jl
@@ -241,9 +241,9 @@ end
         curr_atoms = Vector{QTerm}(undef, length(indexes))
         # replace indexes from neutral with tthose in qterm 
         for (i, ind) in enumerate(indexes)
-            curr_atoms[i] = QTerm(neutral_op, replace_indexes(neutral_op, curr_op_indexes, ind))
+            curr_atoms[i] = QTerm(statespace, replace_indexes(neutral_op, curr_op_indexes, ind))
         end
-        qexpr[j] = QAtomProduct(curr_atoms, coeff_fun*coeff, statespace)
+        qexpr[j] = QAtomProduct(statespace, coeff_fun*coeff, curr_atoms)
     end
     return QCumulant(statespace, copy(atom), qexpr, order, where_acting)
 end

--- a/src/QExpressionsOps/QExpressions_helper.jl
+++ b/src/QExpressionsOps/QExpressions_helper.jl
@@ -75,13 +75,13 @@ end
         end
     end
     if !is_numeric(commuting_qterm, ss)
-        push!(curr_combo, QTerm(commuting_qterm))
+        push!(curr_combo, QTerm(ss, commuting_qterm))
     else
         return [(one(ComplexRational), [x, y])], false
     end
     push!(curr_combo, x)
     if !is_numeric(non_commuting_qterm, ss)
-        push!(curr_combo, QTerm(non_commuting_qterm))
+        push!(curr_combo, QTerm(ss, non_commuting_qterm))
     end
     return Tuple{ComplexRational, Vector{QAtom}}[(one(ComplexRational), curr_combo)], true
 end

--- a/src/QExpressionsOps/QExpressions_reorder.jl
+++ b/src/QExpressionsOps/QExpressions_reorder.jl
@@ -37,7 +37,7 @@ end
 # QObj
 function reorder(q::QTerm, index_order::Vector{Int})::QTerm
     op_indices = q.op_indices[index_order]
-    return QTerm(op_indices)
+    return QTerm(q.statespace, op_indices)
 end
 function reorder(q::QAtomProduct, add_at_sum::Bool,  where_defined::Vector{Vector{Bool}}, index_order::Vector{Int}, var_index_order::Vector{Int})::QAtomProduct
     q.expr = [reorder(qq, index_order) for qq in q.expr]

--- a/src/QExpressionsOps/QExpressions_string2term.jl
+++ b/src/QExpressionsOps/QExpressions_string2term.jl
@@ -37,7 +37,7 @@ function string2qterm(statespace::StateSpace, operator_str::String="")::Tuple{Ve
             curr_coeff *= combo[i][1]
             push!(curr_inds, combo[i][2])
         end
-        push!(terms, QTerm(curr_inds))
+        push!(terms, QTerm(statespace, curr_inds))
         push!(coeffs, curr_coeff)
     end
     return terms, coeffs, var_exponents
@@ -78,7 +78,7 @@ function string2qabstract(statespace::StateSpace, operator_str::String)::QAbstra
         end
     end
     operator_type = statespace.operatortypes[key_index]
-    return QAbstract(operator_type, key_index, subindex, exp, conjugate) # subindex only printed if not -1 
+    return QAbstract(statespace, operator_type, key_index, subindex, exp, conjugate) # subindex only printed if not -1
 end
 
 """


### PR DESCRIPTION
## Summary
- attach StateSpace references to QTerm and QAbstract atoms
- add QEq abstraction with diff_QEq as subtype
- update various helper routines to use new QTerm/QAbstract constructors
- allow `qExpr` containers to store any `QObj`, not just composites
- define `QTerm` inner constructor using `new` to avoid recursive instantiation

## Testing
- `/opt/julia/bin/julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.test()'`


------
https://chatgpt.com/codex/tasks/task_e_689de2fc092c832fabfc05d6a17543ec